### PR TITLE
fix: allow the Node ES module build to run

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,3 +23,6 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Run build
+        run: npm run build:dist

--- a/config/rollup/config.js
+++ b/config/rollup/config.js
@@ -52,7 +52,7 @@ export default [
       file: "dist/node/rougher.mjs",
       format: "es",
     },
-    external: ["jsdom", "roughjs"],
+    external: ["jsdom", "roughjs", "w3c-xmlserializer"],
     plugins: esPlugins,
   },
   {
@@ -62,7 +62,7 @@ export default [
       format: "cjs",
       exports: "default",
     },
-    external: ["jsdom", "roughjs"],
+    external: ["jsdom", "roughjs", "w3c-xmlserializer"],
     plugins: cjsPlugins,
   },
 ];


### PR DESCRIPTION
Refs https://github.com/unindented/rougher/pull/2#issuecomment-889620523.

Doesn't try and built w3c-xmlserializer introduced in #2, which was failing the Node ES module
build as it's CommonJS.

Also added a step to the PR workflow to make sure the build will run successfully.
